### PR TITLE
Fix bracket paths

### DIFF
--- a/lib/file/find.rb
+++ b/lib/file/find.rb
@@ -236,7 +236,6 @@ class File::Find
           file = File.join(path, file)
 
           stat_method = @follow ? :stat : :lstat
-
           # Skip files we cannot access, stale links, etc.
           begin
             stat_info = File.send(stat_method, file)
@@ -247,7 +246,13 @@ class File::Find
             retry if stat_method.to_s != 'lstat'
           end
 
-          glob = File.join(File.dirname(file), @name)
+
+
+          # We need to escape any brackets in the directory
+          # Otherwise it won't appear in Dir[glob], and we
+          # won't descend into directories with brackets
+          glob = File.join(File.dirname(file).gsub(/([\[\]])/,'\\\\\1'), @name)
+
 
           # Dir[] doesn't like backslashes
           if File::ALT_SEPARATOR


### PR DESCRIPTION
There was a serious bug where directories with brackets in the name were not getting traversed correctly.
I created some unit tests and fixed the bug.  I was tempted to get rid of most of the Dir[] code and use Dir.entries, but I'm pretty sure I couldn't replicate functionality.  My tests say this gets everything I care about without breaking any of your stuff.

An unrelated fix in this branch is there was a bug in your test_maxdepth_file that was causing the tests to fail on my machine, so my fix for that is in here too.

BTW, I don't have a windows machine so I'm not positive how these changes work in that environment.  I did test in ruby 1.8.7 and 1.9.3 on linux.  I don't think they should have problems on windows, but I don't know how the core ruby File.fnmatch stuff gets ported.  Since the base problem has to do with how fnmatch handles brackets, it wouldn't blow my mind to find out there were some annoying platform specific issues.
