### PR TITLE
Add Jruby and Truffleruby to workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,8 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
-
+        ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
+        exclude:
+          - ruby-version: truffleruby
+            platform: windows-latest
+          - ruby-version: jruby
+            platform: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
But skip JRuby and Truffleruby on Windows for now.