### PR TITLE
Use fnmatch instead of glob

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,11 @@ on:
 
 jobs:
   test:
+
     strategy:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby', 'truffleruby']
-        platform: [ubuntu-latest, windows-latest]
+        platform: ['ubuntu-latest', 'windows-latest']
         exclude:
           - ruby-version: truffleruby
             platform: windows-latest
@@ -25,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4
-    - name: Setp Ruby
+    - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}

--- a/lib/file/find.rb
+++ b/lib/file/find.rb
@@ -111,7 +111,7 @@ class File::Find
   attr_accessor :mtime
 
   # The name pattern used to limit file searches. The patterns that are legal
-  # for Dir.glob are legal here. The default is '*', i.e. everything.
+  # for File.fnmatch are legal here. The default is '*', i.e. everything.
   #
   attr_accessor :name
 
@@ -248,16 +248,6 @@ class File::Find
             end
           end
 
-          # We need to escape any brackets in the directory name, unless already escaped.
-          temp = File.dirname(file).gsub(/(?<!\\)([\[\]])/, '\\\\\1')
-          glob = File.join(temp, @name)
-
-          # Dir[] doesn't like backslashes
-          if File::ALT_SEPARATOR
-            file.tr!(File::ALT_SEPARATOR, File::SEPARATOR)
-            glob.tr!(File::ALT_SEPARATOR, File::SEPARATOR)
-          end
-
           if @mount && stat_info.dev != @filesystem
             next
           end
@@ -295,7 +285,7 @@ class File::Find
             queue << file
           end
 
-          next unless Dir[glob].include?(file)
+          next unless File.fnmatch?(@name, File.basename(file))
 
           unless @filetest.empty?
             file_test = true


### PR DESCRIPTION
This replaces a somewhat expensive `Dir.glob` call, and related code that was used to make it happy, with a less expensive `File.fnmatch` call.